### PR TITLE
Support cdef option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ NAME
 
 Version
 ----------------
-        0.05
+        0.06
 
 SYNOPSIS
 ---------------
@@ -21,6 +21,7 @@ SYNOPSIS
            [-h|--help]          Print this message.
            [-v|--verbose]       Print verbose messages.
            [-a|--all]           Call all available munin-node plugins.
+           [-c|--cdef]          Adjust values by CDEF from munin-run config.
            [-i|--ignore]        Ignore munin-node plugins with "--all" option.
 
         Examples:

--- a/munin2zabbix-sender.pl
+++ b/munin2zabbix-sender.pl
@@ -9,6 +9,7 @@ use Pod::Usage 'pod2usage';
 ######################################################################
 # DO NOT EDIT following lines
 my $version = [
+    'version 0.06         2016/07/15',
     'version 0.05         2013/03/25',
     'version 0.04         2013/03/22',
     'version 0.03 beta    2013/03/22',


### PR DESCRIPTION
Background: 
http://munin-monitoring.org/wiki/fieldname.cdef

munin's graph CDEF feature can handling with operand like '/' .  but zabbix's graph feature
can not do it.

That is why munin2zabbix-sender adjust values with '-cdef' option.

